### PR TITLE
improve error handling for GET /api/users/:user_id, with testing

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -55,6 +55,30 @@ describe("GET", () => {
       });
     });
     describe("Error Handling", () => {
+      it("status: 400, Bad Request", () => {
+        return request(app)
+          .get("/api/users/words")
+          .expect(400)
+          .then(({ body: { msg } }) => {
+            expect(msg).toBe("user_id must be a positive integer");
+          });
+      });
+      it("status: 400, Bad Request", () => {
+        return request(app)
+          .get("/api/users/-10")
+          .expect(400)
+          .then(({ body: { msg } }) => {
+            expect(msg).toBe("user_id must be a positive integer");
+          });
+      });
+      it("status: 400, Bad Request", () => {
+        return request(app)
+          .get("/api/users/12.5")
+          .expect(400)
+          .then(({ body: { msg } }) => {
+            expect(msg).toBe("user_id must be a positive integer");
+          });
+      });
       it("status: 404, Not Found", () => {
         return request(app)
           .get("/api/users/999")

--- a/models/users.models.js
+++ b/models/users.models.js
@@ -7,6 +7,15 @@ exports.selectUsers = () => {
 };
 
 exports.selectUserByUserId = (user_id) => {
+  // this checks the user_id is a positive integer
+  const num = Number(user_id);
+  if (!(Number.isInteger(num) && num > 0)) {
+    return Promise.reject({
+      status: 400,
+      msg: "user_id must be a positive integer",
+    });
+  }
+
   return db
     .query(`SELECT * FROM users WHERE user_id=$1`, [user_id])
     .then(({ rows: [user] }) => {


### PR DESCRIPTION
checks that user_id is a positive integer, return error: 400, msg: "user_id must be a positive integer" otherwise