### PR TITLE
Update all tables so arrays are defaulted to an empty array

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -444,6 +444,22 @@ describe("PATCH", () => {
             });
           });
       });
+      it("status: 200, works with arrays", () => {
+        return request(app)
+          .patch("/api/users/1")
+          .send({ fav_games: [1, 2] })
+          .expect(200)
+          .then(({ body: { user } }) => {
+            expect(user).toEqual({
+              user_id: 1,
+              username: "BigJ",
+              name: "Joe",
+              email: "joefuller042@gmail.com",
+              fav_games: [1, 2],
+              friends: null,
+            });
+          });
+      });
     });
 
     describe("Error Handling", () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -460,6 +460,23 @@ describe("PATCH", () => {
             });
           });
       });
+
+      it("status: 200, allows inc_games and inc_friends properties", () => {
+        return request(app)
+          .patch("/api/users/1")
+          .send({ inc_games: [3], inc_friends: [1, 2] })
+          .expect(200)
+          .then(({ body: { user } }) => {
+            expect(user).toEqual({
+              user_id: 1,
+              username: "BigJ",
+              name: "Joe",
+              email: "joefuller042@gmail.com",
+              fav_games: [3],
+              friends: [1, 2],
+            });
+          });
+      });
     });
 
     describe("Error Handling", () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -48,8 +48,8 @@ describe("GET", () => {
               username: "BigJ",
               name: "Joe",
               email: "joefuller042@gmail.com",
-              friends: null,
-              fav_games: null,
+              friends: [],
+              fav_games: [],
             });
           });
       });
@@ -224,7 +224,7 @@ describe("GET", () => {
               organiser: 2,
               visibility: true,
               willing_to_teach: false,
-              games: null,
+              games: [],
               guests: [1, 2],
             });
           });
@@ -340,8 +340,8 @@ describe("POST", () => {
               username: "Facility",
               name: "Felicity",
               email: "fbomb@hotmail.co.uk",
-              fav_games: null,
-              friends: null,
+              fav_games: [],
+              friends: [],
             });
           });
       });
@@ -386,8 +386,8 @@ describe("POST", () => {
               start_time: "12:00:00",
               duration: null,
               organiser: 1,
-              guests: null,
-              games: null,
+              guests: [],
+              games: [],
               visibility: true,
               willing_to_teach: false,
             });
@@ -423,8 +423,8 @@ describe("PATCH", () => {
               username: "BigJ",
               name: "Joe",
               email: "newemail@email.com",
-              fav_games: null,
-              friends: null,
+              fav_games: [],
+              friends: [],
             });
           });
       });
@@ -439,8 +439,8 @@ describe("PATCH", () => {
               username: "BigJ",
               name: "Joe",
               email: "newemail@email.com",
-              fav_games: null,
-              friends: null,
+              fav_games: [],
+              friends: [],
             });
           });
       });
@@ -456,7 +456,7 @@ describe("PATCH", () => {
               name: "Joe",
               email: "joefuller042@gmail.com",
               fav_games: [1, 2],
-              friends: null,
+              friends: [],
             });
           });
       });
@@ -532,7 +532,7 @@ describe("PATCH", () => {
               duration: 120,
               organiser: 2,
               guests: [1, 2],
-              games: null,
+              games: [],
               visibility: true,
               willing_to_teach: false,
             });
@@ -557,7 +557,7 @@ describe("PATCH", () => {
               duration: 120,
               organiser: 2,
               guests: [1, 2],
-              games: null,
+              games: [],
               visibility: false,
               willing_to_teach: false,
             });

--- a/database/seeds/seed.js
+++ b/database/seeds/seed.js
@@ -14,8 +14,8 @@ const seed = async (data) => {
             username VARCHAR NOT NULL,
             name VARCHAR,
             email VARCHAR,
-            friends INT [],
-            fav_games INT []
+            friends INT[] DEFAULT ARRAY[]::INT[],
+            fav_games INT[] DEFAULT ARRAY[]::INT[]
         );`);
 
   // check best way to store date/time
@@ -34,8 +34,8 @@ const seed = async (data) => {
             organiser INT NOT NULL REFERENCES users(user_id),
             visibility BOOLEAN DEFAULT true,
             willing_to_teach BOOLEAN DEFAULT false,
-            guests INT[],
-            games INT[]
+            guests INT[] DEFAULT ARRAY[]::INT[],
+            games INT[] DEFAULT ARRAY[]::INT[]
         );`);
 
   await db.query(`

--- a/models/users.models.js
+++ b/models/users.models.js
@@ -64,7 +64,15 @@ exports.updateUser = (user_id, body) => {
     return Promise.reject({ status: 400, msg: "Bad Request" });
   }
 
-  const validKeys = ["username", "name", "email", "fav_games", "friends"];
+  const validKeys = [
+    "username",
+    "name",
+    "email",
+    "fav_games",
+    "friends",
+    "inc_games",
+    "inc_friends",
+  ];
 
   const keys = Object.keys(body);
 
@@ -74,6 +82,10 @@ exports.updateUser = (user_id, body) => {
     if (validKeys.includes(key)) {
       if (key === "fav_games" || key === "friends") {
         queryString += `${key}='{${body[key]}}', `;
+      } else if (key === "inc_games") {
+        queryString += `fav_games=ARRAY_CAT(fav_games, ARRAY[${body["inc_games"]}]), `;
+      } else if (key === "inc_friends") {
+        queryString += `friends=ARRAY_CAT(friends, ARRAY[${body["inc_friends"]}]), `;
       } else {
         queryString += `${key}='${body[key]}', `;
       }

--- a/models/users.models.js
+++ b/models/users.models.js
@@ -64,7 +64,7 @@ exports.updateUser = (user_id, body) => {
     return Promise.reject({ status: 400, msg: "Bad Request" });
   }
 
-  const validKeys = ["username", "name", "email"];
+  const validKeys = ["username", "name", "email", "fav_games", "friends"];
 
   const keys = Object.keys(body);
 
@@ -72,7 +72,11 @@ exports.updateUser = (user_id, body) => {
 
   for (const key of keys) {
     if (validKeys.includes(key)) {
-      queryString += `${key}='${body[key]}', `;
+      if (key === "fav_games" || key === "friends") {
+        queryString += `${key}='{${body[key]}}', `;
+      } else {
+        queryString += `${key}='${body[key]}', `;
+      }
     }
   }
 


### PR DESCRIPTION
Updated tests to reflect this

Also, I updated PATCH /api/users/:user_id so you can either send it "games" or "friends" to change the entire array, or "inc_games" or "inc_friends" (as an array) to add to the current games or friends arrays